### PR TITLE
Finally set up the fct_hourly_rides model

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -24,6 +24,8 @@ quoting:
 
 models:
   thesis:
+    marts:
+      materialized: table
     vars:
       ride_tables:
       - rides_201601

--- a/models/marts/fct_hourly_rides.sql
+++ b/models/marts/fct_hourly_rides.sql
@@ -1,3 +1,4 @@
+
 with rides_1 as (
 
     select * from {{ref('stg_citibikes')}}
@@ -6,11 +7,11 @@ with rides_1 as (
 
 normalized_timestamp as (
 
-    select * ,
-    case when to_timestamp(starttime, 'MM/DD/YYYY HH24:MI:SS')::timestamp < '2016-10-01'
-    THEN to_timestamp(starttime, 'MM/DD/YYYY HH24:MI:SS')::timestamp
-    ELSE to_timestamp(starttime, 'YYYY-MM-DD HH24:MI:SS')::timestamp
-    END AS fixed_timestamp
+  select * ,
+   case when to_timestamp(starttime, 'YYYY-MM-DD HH24:MI:SS')::timestamp >= '2016-10-01'
+   THEN to_timestamp(starttime, 'YYYY-MM-DD HH24:MI:SS')::timestamp
+   ELSE to_timestamp(starttime, 'MM/DD/YYYY HH24:MI:SS')::timestamp
+   END AS fixed_timestamp
 
 from rides_1
 ),
@@ -21,6 +22,7 @@ fix_dates_1 as (
     select
        date_trunc('hour', fixed_timestamp) as start_time,
        extract(hour from fixed_timestamp) as start_hour,
+     fixed_timestamp::date as date_day,
        *
    from normalized_timestamp
 
@@ -31,9 +33,10 @@ hourly_1 as (
     select
         start_time,
         start_hour,
+        date_day,
         count(*) as total_rides
     from fix_dates_1
-    group by 1,2
+    group by 1,2,3
 
 )
 

--- a/models/marts/fct_hourly_weather.sql
+++ b/models/marts/fct_hourly_weather.sql
@@ -3,14 +3,15 @@ with weather as (
 
     select *
 
-from thesis.weather
+from {{ref('stg_weather')}}
+
 
 ),
 
 weather_fixed as (
 
-    select date_trunc('hour', (to_timestamp(measure_time, 'DD/MM/YYYY HH24:MI:SS'))::timestamp) as start_time,
-       extract(hour from (to_timestamp(measure_time, 'DD/MM/YYYY HH24:MI:SS'))::timestamp) as start_hour,
+    select date_trunc('hour', (to_timestamp(measure_time, 'MM/DD/YYYY HH24:MI:SS'))::timestamp) as start_time,
+       extract(hour from (to_timestamp(measure_time, 'MM/DD/YYYY HH24:MI:SS'))::timestamp) as start_hour,
        *
 
 from weather

--- a/models/marts/rides_weather_joined.sql
+++ b/models/marts/rides_weather_joined.sql
@@ -16,13 +16,65 @@ from {{ref('fct_hourly_weather')}}
 
 ),
 
+holidays as (
+
+    select *
+    from {{ref('stg_holidays')}}
+
+
+),
+
 rides_weather_joined as (
 
-select *
+select *,
+
+case when holidays.holiday is not null
+then 1
+else 0
+end as is_holiday
 
 from hourly_rides
 left join hourly_weather
 using (start_time, start_hour)
+left join holidays
+using (date_day)
+),
+
+rides_weekday as (
+
+select extract (dow from date_day) as dow,
+extract (mon from date_day) as month ,
+extract (d from date_day) as day,
+*
+
+from rides_weather_joined
+
+),
+
+weekend_flag as (
+
+select *,
+
+case when dow = 0 or dow = 6
+then 1
+else 0
+end as is_weekend ,
+
+case when month in (1 ,2) OR  (month = 3 and day < 20)
+then 'winter'
+when month in (3,4,5) OR (month = 6 and day < 20 )
+then 'spring'
+when month in (6, 7,8 ) OR (month = 9 and day < 22)
+then 'summer'
+when month in (9, 10, 11) OR (month = 12 and day < 22)
+then 'fall'
+when month = 12 and day >= 22 then 'winter'
+else NULL
+
+end as season
+
+from rides_weekday
+
 )
 
-select * from rides_weather_joined
+select * from weekend_flag

--- a/models/marts/schema.yml
+++ b/models/marts/schema.yml
@@ -1,0 +1,26 @@
+version: 2
+
+models:
+    - name: rides_weather_joined
+      description: JOINS EVERYTHING
+      columns:
+          - name: start_time
+            tests:
+                - not_null
+                - unique
+
+    - name: fct_hourly_weather
+      description: JOINS EVERYTHING
+      columns:
+          - name: start_time
+            tests:
+                - not_null
+                - unique
+
+    - name: stg_weather
+      description: JOINS EVERYTHING
+      columns:
+          - name: measure_time
+            tests:
+                - not_null
+                - unique

--- a/models/staging/stg_holidays.sql
+++ b/models/staging/stg_holidays.sql
@@ -1,0 +1,3 @@
+select "date"::date as date_day, holiday
+
+from thesis.holidays

--- a/models/staging/stg_weather.sql
+++ b/models/staging/stg_weather.sql
@@ -1,0 +1,13 @@
+with source as (
+
+select measure_time,
+temperature,
+precipitation,
+windspeed,
+row_number() over (partition by measure_time order by random() ) as index
+
+from thesis.weather
+)
+
+select * from source
+where index = 1


### PR DESCRIPTION
In this PR, we were able to finally set up the fct_hourly_rides model. This is a summary of what this took . 
**dbt project file:**

- We chose to materialize the models as tables instead of views.

**staging models**

- Staging rides : the stg_citibike model unions the citibike tables together. 
- Staging weather : the stg_weather model deduplicates the weather data and lists out the fields.
- Staging holidays: the stg_holidays model converts the date column to a date_day field of data type date . 

**fct_hourly_weather**

- incorporated a ref
- changed timestamp format to MM/DD instead of DD/MM. This was causing duplication in our final join. 

**fct_hourly_rides**
- changed the case when statement to fill data from October 2016-December 2017 BEFORE filling January 2016 - September 2016. The case when statement was not working correctly prior to this change, and seems to have something to do with the way that the function is built. We ran a min(date)/max(date) query after making this change to make sure there were no further issues. 

- Also incorporated a date_day field 

**rides_weather_joined**
- This model joins 3 different models together: fct_hourly_rides, fct_hourly_weather, and holidays.

- Creates a binary holidays y/n field

- Creates day of week, month, and day fields by extracting them from the date_day field. The dow function in Redshift assigns a day a number from 0 to 6. 

- Creates a is_holiday field to flag if a field is a holiday or not. 

- Creates a season field.

**schema.yml file**

- Added not null and uniqueness tests for rides_weather_joined, fct_hourly_weather and stg_weather. 


Notes: more tests to be added and assigned to correct folders in follow up PRs.


